### PR TITLE
Add gtk4, python-cairo, and libadwaita to README and PKGBUILD 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd biglinux-noise-reduction-pipewire
 
 For Arch-based systems:
 ```bash
-sudo pacman -S noise-suppression-for-voice-big pipewire swh-plugins python-numpy gettext python-gobject
+sudo pacman -S --needed noise-suppression-for-voice-big pipewire swh-plugins python-numpy gettext python-gobject gtk4 libadwaita python-cairo
 ```
 
 For Debian/Ubuntu-based systems:

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -7,7 +7,7 @@ arch=('any')
 license=('GPL')
 url="https://github.com/biglinux/biglinux-noise-reduction-pipewire"
 pkgdesc="Interface to enable or disable microphone noise reduction, using https://github.com/werman/noise-suppression-for-voice"
-depends=('noise-suppression-for-voice-big' 'pipewire' 'swh-plugins' 'python-numpy' 'gettext' 'python-gobject')
+depends=('noise-suppression-for-voice-big' 'pipewire' 'swh-plugins' 'python-numpy' 'gettext' 'python-gobject' 'gtk4' 'libadwaita' 'python-cairo')
 # This not provide a real ladspa host, but pipewire provides
 provides=(
   ladspa-host


### PR DESCRIPTION
Added gtk4, python-cairo, and libadwaita dependencies to the installation instructions for Arch-based systems in the README.md.

They were also added to the PKGBUILD.

These packages are required to avoid runtime errors on distributions like Arch and Manjaro.