### PR TITLE
Fix spectrum data handling in on_message for AudioVisualizer

### DIFF
--- a/usr/share/biglinux/microphone/audio_visualizer.py
+++ b/usr/share/biglinux/microphone/audio_visualizer.py
@@ -621,8 +621,15 @@ class AudioVisualizer(Gtk.Box):
             structure = message.get_structure()
             if structure:
                 # Get the magnitude array
-                magnitudes = structure.get_value("magnitude")
-                if magnitudes:
+                magnitudes_gtype = structure.get_list("magnitude")
+                magnitudes_varray = magnitudes_gtype[1]
+
+                magnitudes = [
+                    magnitudes_varray.get_nth(i)
+                    for i in range(magnitudes_varray.n_values)
+                ]
+
+                if magnitudes_gtype[0]:
                     self.last_spectrum_time = time.time()
                     self.process_spectrum_data(magnitudes)
                     return True


### PR DESCRIPTION
This PR modifies the `on_message` method in the `AudioVisualizer` class to properly handle spectrum messages from the GStreamer bus.

The issue was observed on `biglinux_2025-11-17_k612` (installed on both a personal machine and in a VM). The noise reducer was not working correctly in the visualization and returned error messages that helped diagnose the problem.

<img width="1920" height="1080" alt="DebugAPP1" src="https://github.com/user-attachments/assets/2ab7ed12-3aed-4465-b71a-e8afe78a44c0" />

A similar issue has been discussed on the GStreamer forum:  [Python: get_structure() API change?](https://discourse.gstreamer.org/t/python-get-structure-api-change/4767)

### Changes:

`message.get_structure()`  returns a Gst.Structure whose "magnitude" field is stored as a GstValueList instead of a simple Python-convertible type. Because of this, calling get_value("magnitude") raises a type error. Following the documentation [1], I updated the code to use get_list("magnitude"), which returns a tuple (bool, array: GObject.ValueArray). This allows us to work with the GObject.ValueArray via its get_nth() method [2] to retrieve each spectrum value, using the boolean as a success flag.

### Documentation consulted:

[1 - Gst.Structure.get_list](https://lazka.github.io/pgi-docs/Gst-1.0/structs/Structure.html#Gst.Structure.get_list)  
[2 - GObject.ValueArray.get_nth](https://lazka.github.io/pgi-docs/GObject-2.0/classes/ValueArray.html#GObject.ValueArray.get_nth)
[3 - Gst.Structure.has_field](https://lazka.github.io/pgi-docs/Gst-1.0/structs/Structure.html#Gst.Structure.has_field)

After applying these changes, the software returned to normal operation:

<img width="1920" height="1080" alt="DebugAPP2" src="https://github.com/user-attachments/assets/cffb7af5-ecf8-4faf-b5bc-ab95b38e8511" />


Since I am not certain about the GStreamer versions installed on other systems, I cannot tell whether this was a bug specific to my setup or a more general issue. In any case, I am sharing my solution for review.

I believe `get_list()` and the added checks offer better cross-version support in GStreamer/PyGObject.